### PR TITLE
Add peer-observer protobuf integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "peer-observer"]
+	path = peer-observer
+	url = https://github.com/deadmanoz/peer-observer.git

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,11 @@ keywords = ["bitcoin", "mempool", "monitoring", "analysis"]
 categories = ["bitcoin"]
 
 [dependencies]
+prost = "0.14.1"
+serde = { version = "1.0", features = ["derive"] }
+
+[build-dependencies]
+prost-build = "0.14"
 
 [lints.clippy]
 pedantic = { level = "warn", priority = -1 }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,31 @@
+use prost_build;
+
+fn main() {
+    // Generate Rust types for all protobuf definitions from peer-observer
+    let proto_files = [
+        "peer-observer/protobuf/proto-types/event_msg.proto",
+        "peer-observer/protobuf/proto-types/mempool.proto", 
+        "peer-observer/protobuf/proto-types/net_msg.proto",
+        "peer-observer/protobuf/proto-types/net_conn.proto",
+        "peer-observer/protobuf/proto-types/addrman.proto",
+        "peer-observer/protobuf/proto-types/validation.proto",
+        "peer-observer/protobuf/proto-types/rpc.proto",
+        "peer-observer/protobuf/proto-types/primitive.proto",
+    ];
+
+    if let Err(e) = prost_build::Config::new()
+        .compile_well_known_types()
+        .type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]")
+        .compile_protos(
+            &proto_files,
+            &["peer-observer/protobuf/proto-types/"],
+        )
+    {
+        println!("Error while compiling protos: {}", e);
+        panic!("Failed to code-gen the Rust structs from the Protobuf definitions");
+    }
+
+    // Rebuild if protobuf files change
+    println!("cargo:rerun-if-changed=peer-observer/protobuf/proto-types/");
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,35 @@
+// Include the generated protobuf types
+pub mod event_msg {
+    include!(concat!(env!("OUT_DIR"), "/event_msg.rs"));
+}
+pub mod mempool {
+    include!(concat!(env!("OUT_DIR"), "/mempool.rs"));
+}
+pub mod net_msg {
+    include!(concat!(env!("OUT_DIR"), "/net_msg.rs"));
+}
+pub mod net_conn {
+    include!(concat!(env!("OUT_DIR"), "/net_conn.rs"));
+}
+pub mod addrman {
+    include!(concat!(env!("OUT_DIR"), "/addrman.rs"));
+}
+pub mod validation {
+    include!(concat!(env!("OUT_DIR"), "/validation.rs"));
+}
+pub mod rpc {
+    include!(concat!(env!("OUT_DIR"), "/rpc.rs"));
+}
+pub mod primitive {
+    include!(concat!(env!("OUT_DIR"), "/primitive.rs"));
+}
+
 fn main() {
-    println!("The Times 03/Jan/2009 Chancellor on brink of second bailout for banks");
+    println!("Rust Memo - Bitcoin Mempool Monitor");
+    
+    // Test that we can access the protobuf types
+    println!("Protobuf types available:");
+    println!("- EventMsg from peer-observer");
+    println!("- MempoolEvent types");
+    println!("- Network message types");
 }


### PR DESCRIPTION
- Add peer-observer as git submodule (deadmanoz fork)
- Configure protobuf compilation via build.rs
- Add prost dependencies to Cargo.toml
- Update main.rs with protobuf module imports
- Enable synchronized message definitions with peer-observer